### PR TITLE
Mido update

### DIFF
--- a/midi_cmd_server.py
+++ b/midi_cmd_server.py
@@ -91,8 +91,7 @@ def uptime():
 # keep running and watch for midi cc
 while True:
   time.sleep(.01)
-  while inport.pending():
-    msg = inport.receive()
+  for msg in inport:
     if msg.type == "control_change":
       if msg.control in cc_cmds:
         if msg.value in cc_cmds[msg.control]:

--- a/midi_cmd_server.py
+++ b/midi_cmd_server.py
@@ -90,7 +90,6 @@ def uptime():
 
 # keep running and watch for midi cc
 for msg in inport:
-  print( msg )
   if msg.type == "control_change":
     if msg.control in cc_cmds:
       if msg.value in cc_cmds[msg.control]:

--- a/midi_cmd_server.py
+++ b/midi_cmd_server.py
@@ -89,33 +89,32 @@ def uptime():
     return uptime_seconds
 
 # keep running and watch for midi cc
-while True:
-  time.sleep(.01)
-  for msg in inport:
-    if msg.type == "control_change":
-      if msg.control in cc_cmds:
-        if msg.value in cc_cmds[msg.control]:
+for msg in inport:
+  print( msg )
+  if msg.type == "control_change":
+    if msg.control in cc_cmds:
+      if msg.value in cc_cmds[msg.control]:
+        # apped " &" to the end of commands, to run them in background
+        # and immediately get back to the script
+        myCmd = cc_cmds[msg.control][msg.value]["cmd"] + " &"
+        upCheck = cc_cmds[msg.control][msg.value]["uptime"]
+        if upCheck > 0:
+          if uptime() > upCheck:
+            os.system(myCmd)
+        else:
+          os.system(myCmd)
+  if msg.type == "note_on":
+    if msg.note in note_cmds:
+      if msg.velocity > note_cmds[msg.note]["velocity"]:
+        # do not trigger too quickly on notes
+        if note_cmds[msg.note]["lastTriggered"] + note_cmd_retrigger_delay < uptime():
+          note_cmds[msg.note]["lastTriggered"] = uptime()
           # apped " &" to the end of commands, to run them in background
           # and immediately get back to the script
-          myCmd = cc_cmds[msg.control][msg.value]["cmd"] + " &"
-          upCheck = cc_cmds[msg.control][msg.value]["uptime"]
+          myCmd = note_cmds[msg.note]["cmd"] + " &"
+          upCheck = note_cmds[msg.note]["uptime"]
           if upCheck > 0:
             if uptime() > upCheck:
               os.system(myCmd)
           else:
             os.system(myCmd)
-    if msg.type == "note_on":
-      if msg.note in note_cmds:
-        if msg.velocity > note_cmds[msg.note]["velocity"]:
-          # do not trigger too quickly on notes
-          if note_cmds[msg.note]["lastTriggered"] + note_cmd_retrigger_delay < uptime():
-            note_cmds[msg.note]["lastTriggered"] = uptime()
-            # apped " &" to the end of commands, to run them in background
-            # and immediately get back to the script
-            myCmd = note_cmds[msg.note]["cmd"] + " &"
-            upCheck = note_cmds[msg.note]["uptime"]
-            if upCheck > 0:
-              if uptime() > upCheck:
-                os.system(myCmd)
-            else:
-              os.system(myCmd)


### PR DESCRIPTION
Mido docs have a note:

```
Deprecated since version 1.2: There used to be a pending() method
which returned the number of pending messages.

It was removed for three reasons:

    - with poll() and iter_pending() it is no longer necessary
    - it was unreliable when multithreading and for some ports
      it doesn’t even make sense
    - it made the internal method API confusing. _send() sends a 
      message so _receive() should receive a message.
```

Sure enough, on the latest patchbox OS, this script needs an update.  This appears to do the trick.   I also removed the outer `while()`, as the new iterator is blocking, and only returns if the port closes.
